### PR TITLE
Update boring and quinn versions

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -7,6 +7,7 @@ description = "BoringSSL crypto provider for quinn"
 keywords = ["quic"]
 categories = ["network-programming", "asynchronous"]
 edition = "2021"
+rust-version = "1.70"
 
 [badges]
 maintenance = { status = "passively-maintained" }
@@ -15,14 +16,15 @@ maintenance = { status = "passively-maintained" }
 fips = ["boring/fips", "boring-sys/fips"]
 
 [dependencies]
-boring = "2.1.0"
-boring-sys = "2.1.0"
+# Switch back to cloudflare's repo once https://github.com/cloudflare/boring/pull/132 lands.
+boring = { git = "https://github.com/nmittler/boring/", branch = "hmac" }
+boring-sys = { git = "https://github.com/nmittler/boring/", branch = "hmac" }
 bytes = "1"
 foreign-types-shared = "0.3.1"
 lru = "0.11.0"
 once_cell = "1.17"
-quinn = { version = "0.9.3", default_features = false, features = ["native-certs", "runtime-tokio"] }
-quinn-proto = { version = "0.9.3", default-features = false }
+quinn = { version = "0.10.1", default_features = false, features = ["native-certs", "runtime-tokio"] }
+quinn-proto = { version = "0.10.1", default-features = false }
 rand = "0.8"
 tracing = "0.1"
 

--- a/examples/client.rs
+++ b/examples/client.rs
@@ -108,7 +108,7 @@ async fn run(options: Opt) -> Result<()> {
         .await
         .map_err(|e| anyhow!("failed to connect: {}", e))?;
     eprintln!("connected at {:?}", start.elapsed());
-    let (mut send, recv) = conn
+    let (mut send, mut recv) = conn
         .open_bi()
         .await
         .map_err(|e| anyhow!("failed to open stream: {}", e))?;

--- a/examples/server.rs
+++ b/examples/server.rs
@@ -211,7 +211,7 @@ async fn handle_connection(root: Arc<Path>, conn: quinn::Connecting) -> Result<(
 
 async fn handle_request(
     root: Arc<Path>,
-    (mut send, recv): (quinn::SendStream, quinn::RecvStream),
+    (mut send, mut recv): (quinn::SendStream, quinn::RecvStream),
 ) -> Result<()> {
     let req = recv
         .read_to_end(64 * 1024)

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -80,7 +80,12 @@ pub mod helpers {
     /// communicate within.
     pub fn client_endpoint(addr: SocketAddr) -> io::Result<quinn::Endpoint> {
         let socket = std::net::UdpSocket::bind(addr)?;
-        quinn::Endpoint::new(default_endpoint_config(), None, socket, TokioRuntime)
+        quinn::Endpoint::new(
+            default_endpoint_config(),
+            None,
+            socket,
+            Arc::new(TokioRuntime),
+        )
     }
 
     /// Helper to construct an endpoint for use with both incoming and outgoing connections
@@ -98,7 +103,7 @@ pub mod helpers {
             default_endpoint_config(),
             Some(config),
             socket,
-            TokioRuntime,
+            Arc::new(TokioRuntime),
         )
     }
 }

--- a/tests/integration_tests.rs
+++ b/tests/integration_tests.rs
@@ -330,7 +330,7 @@ impl Client {
     }
 
     async fn receive_pong(&self) -> Result<()> {
-        let recv = self.conn.accept_uni().await?;
+        let mut recv = self.conn.accept_uni().await?;
         let resp = recv.read_to_end(usize::MAX).await?;
         assert_eq!(PONG_MSG, resp.as_slice());
         Ok(())
@@ -447,7 +447,7 @@ impl Server {
         Ok(())
     }
 
-    async fn receive_ping(recv: RecvStream) -> Result<()> {
+    async fn receive_ping(mut recv: RecvStream) -> Result<()> {
         let req = recv
             .read_to_end(64 * 1024)
             .await


### PR DESCRIPTION
The latest boring on master does not include hmac.h, so temporarily using a custom branch until it's fixed in upstream.