### PR TITLE
Switch back to cloudflare boring

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -16,9 +16,9 @@ maintenance = { status = "passively-maintained" }
 fips = ["boring/fips", "boring-sys/fips"]
 
 [dependencies]
-# Switch back to cloudflare's repo once https://github.com/cloudflare/boring/pull/132 lands.
-boring = { git = "https://github.com/nmittler/boring/", branch = "hmac" }
-boring-sys = { git = "https://github.com/nmittler/boring/", branch = "hmac" }
+# TODO(nmittler): switch to standard release that includes https://github.com/cloudflare/boring/pull/136
+boring = { git = "https://github.com/cloudflare/boring/", rev = "74fd7a8" }
+boring-sys = { git = "https://github.com/cloudflare/boring/", rev = "74fd7a8" }
 bytes = "1"
 foreign-types-shared = "0.3.1"
 lru = "0.11.0"


### PR DESCRIPTION
Now that https://github.com/cloudflare/boring/pull/132 has landed, we can go back to the main repository.